### PR TITLE
chore: Bump version name for release and beta builds

### DIFF
--- a/config.gradle.kts
+++ b/config.gradle.kts
@@ -10,7 +10,7 @@ extra["branchConfigs"] = mapOf(
         "enableLogging" to false,
         "versionCode" to 111,
         "versionName" to "1.1.1",
-        "archivesBaseName" to "藥到叮嚀-v1.1.1"
+        "archivesBaseName" to "藥到叮嚀-v1.1.2"
     ),
     "beta" to mapOf(
         "applicationId" to "com.example.medicationreminderapp.beta",
@@ -20,7 +20,7 @@ extra["branchConfigs"] = mapOf(
         "enableLogging" to true,
         "versionCode" to 11,
         "versionName" to "0.1.1",
-        "archivesBaseName" to "藥到叮嚀-v0.1.1-beta"
+        "archivesBaseName" to "藥到叮嚀-v0.1.2-beta"
     ),
     "alpha" to mapOf(
         "applicationId" to "com.example.medicationreminderapp.alpha",


### PR DESCRIPTION
This commit updates the `archivesBaseName` for the `release` and `beta` build variants in the Gradle configuration.

- **`config.gradle.kts`:**
    - The `release` archive base name is changed from `v1.1.1` to `v1.1.2`.
    - The `beta` archive base name is changed from `v0.1.1-beta` to `v0.1.2-beta`.