### PR TITLE
build: Refine versioning script and app naming for dev branches

### DIFF
--- a/log.md
+++ b/log.md
@@ -7,9 +7,10 @@
         *   **VersionCode:** 自動使用 Git 總提交次數 (`rev-list --count HEAD`)。
         *   **VersionName:**
             *   `main` 分支: `1.1.8.<commitCount>`
-            *   `dev` 分支: `1.1.8-dev.<commitCount>-<shortHash>`
+            *   其他分支: `1.1.8-<branch>.<commitCount>-<shortHash>`
         *   **ArchivesBaseName:** 自動格式化為 `藥到叮嚀-v<VersionName>`。
-    *   **修復:** 解決了 `build.gradle.kts` 中執行 Git 指令時因 `TimeUnit` 引用錯誤導致的 Sync 失敗問題。
+        *   **AppName:** 開發分支會自動加上 `(<branch>)` 後綴。
+    *   **修復:** 解決了 `build.gradle.kts` 中執行 Git 指令時因 `TimeUnit` 引用錯誤導致的 Sync 失敗問題，並修正了未使用的參數警告。
 
 ## UI/UX 調整
 *   **0101:** **修正圖表線條顏色與顯示樣式。**


### PR DESCRIPTION
This commit updates the Gradle build script to improve the automated versioning and application naming scheme, making it easier to distinguish between different development builds.

### Key Changes:

-   **`log.md`:**
    -   **Dynamic Versioning:** The `VersionName` for non-main branches is now generalized to the format `1.1.8-<branch>.<commitCount>-<shortHash>`, replacing the hardcoded `-dev` suffix.
    -   **Dynamic App Name:** For development branches, the application name (`AppName`) will now automatically include the branch name as a suffix (e.g., `AppName (<branch>)`).
    -   **Build Script Fixes:** The log entry now also notes that unused parameter warnings and a `TimeUnit` reference error in the `build.gradle.kts` script have been resolved.