### PR TITLE
ci: Implement triple-track release strategy and version automation

### DIFF
--- a/.github/workflows/android-cicd.yml
+++ b/.github/workflows/android-cicd.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches:
       - main
-      - '**' # Trigger on all branches for nightly builds (except main, handled by conditional)
+      - '**' # Trigger on all branches for nightly builds
+    tags:
+      - 'v*' # Trigger on tags starting with v (e.g. v1.0.0)
   pull_request:
     branches:
       - main
@@ -57,6 +59,11 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          
+          # Inject Versioning Info
+          BUILD_NUMBER: ${{ github.run_number }}
+          # Logic: If it's a tag, use the tag name. Otherwise, use branch-nightly.
+          VERSION_NAME: ${{ github.ref_type == 'tag' && github.ref_name || format('{0}-nightly', github.ref_name) }}
         run: ./gradlew assembleRelease --stacktrace
 
       - name: Get Version Name
@@ -70,10 +77,6 @@ jobs:
         run: |
           # Handle spaces in VERSION_NAME by replacing them with dashes for the filename
           SAFE_VERSION_NAME=$(echo "${{ steps.version.outputs.VERSION_NAME }}" | sed 's/ /-/g')
-          
-          # Gradle puts the signed APK in app/build/outputs/apk/release/
-          # The filename usually defaults to app-release.apk or defined in build.gradle
-          # Our build.gradle sets archivesBaseName, so it might be something like MedicationReminderApp-v1.1.8-nightly-5-release.apk
           
           # Find any APK in the release folder
           TARGET_APK=$(find app/build/outputs/apk/release -name "*.apk" | head -n 1)
@@ -94,32 +97,61 @@ jobs:
           path: app/build/outputs/apk/release/${{ env.APK_FILENAME }}
           retention-days: 7
 
-      - name: Create Release (Main - Stable)
-        if: github.ref == 'refs/heads/main'
+      # ------------------------------------------------------------------
+      # Release Strategy: Triple Track
+      # 1. Official Release (Tags starting with v) -> Permanent Release
+      # 2. Dev Release (Push to dev branch) -> Rolling "latest-dev" Release
+      # 3. Nightly Release (Push to other branches) -> Rolling "nightly" Release
+      # ------------------------------------------------------------------
+
+      # ------------------------------------------------------------------
+      # 1. 正式版發布 (Stable)
+      # 觸發條件：只有當你打上 v 開頭的 Tag 時 (例如 v1.0.0)
+      # ------------------------------------------------------------------
+      - name: Create Official Release
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: v${{ steps.version.outputs.VERSION_NAME }}
-          name: Release v${{ steps.version.outputs.VERSION_NAME }}
-          files: app/build/outputs/apk/release/${{ env.APK_FILENAME }}
-          draft: false
+          files: app/build/outputs/apk/release/*.apk
           prerelease: false
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create Release (Nightly)
-        if: github.ref != 'refs/heads/main' && github.event_name != 'pull_request'
-        uses: softprops/action-gh-release@v1
+      # ------------------------------------------------------------------
+      # 2. Dev 開發版 (Beta)
+      # 觸發條件：推送至 'dev' 分支時
+      # 用途：這是一個相對穩定的測試版，未來可讓內部測試人員更新
+      # ------------------------------------------------------------------
+      - name: Update Dev Release
+        if: github.ref == 'refs/heads/dev'
+        uses: marvinpinto/action-automatic-releases@latest
         with:
-          tag_name: nightly
-          name: Nightly Build (${{ steps.version.outputs.VERSION_NAME }})
-          files: app/build/outputs/apk/release/${{ env.APK_FILENAME }}
-          draft: false
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          automatic_release_tag: "latest-dev"
           prerelease: true
-          generate_release_notes: true
-          body: |
-            Nightly build for version **${{ steps.version.outputs.VERSION_NAME }}**
-            Branch: ${{ github.ref_name }}
-            Commit: ${{ github.sha }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          title: "Dev Build (開發預覽版)"
+          files: |
+            app/build/outputs/apk/release/*.apk
+
+      # ------------------------------------------------------------------
+      # 3. Nightly 實驗版 (Nightly)
+      # 觸發條件：推送至其他分支 (如 fix-setlist, feature-login) 且不是 Tag
+      # 用途：給開發者自己驗證功能用，每次都會覆蓋
+      # ------------------------------------------------------------------
+      - name: Update Nightly Release
+        # 邏輯：是 Push 事件 + 不是 Tag + 不是 dev 分支 + 不是 main/master 分支
+        if: |
+          github.event_name == 'push' && 
+          !startsWith(github.ref, 'refs/tags/') && 
+          github.ref != 'refs/heads/dev' && 
+          github.ref != 'refs/heads/main' && 
+          github.ref != 'refs/heads/master'
+        uses: marvinpinto/action-automatic-releases@latest
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          automatic_release_tag: "nightly"
+          prerelease: true
+          title: "Nightly Build (實驗分支)"
+          files: |
+            app/build/outputs/apk/release/*.apk

--- a/README.md
+++ b/README.md
@@ -32,12 +32,13 @@ To ensure compatibility between the App and the ESP32 firmware as features evolv
 2.  **Open in Android Studio:** Import the project into Android Studio (Ladybug | 2024.2.1 or later recommended).
 3.  **Build and Run:** Connect an Android device (Android 10+) or use an emulator to run the application.
 
-## CI/CD
+## CI/CD & Versioning
 
-This project uses GitHub Actions for continuous integration and deployment.
+This project uses GitHub Actions for continuous integration and automated version management.
 
-*   **Stable Releases:** Pushes to the `main` branch trigger a release build, creating a tagged release (e.g., `v1.1.8.x`).
-*   **Nightly Builds:** Pushes to the `dev` branch trigger a pre-release build, updating the `nightly` tag with the latest changes.
+*   **Tag Releases:** Pushing a tag (e.g., `1.1.9`) triggers a stable release build. The APK version will match the tag name.
+*   **Nightly Builds:** Pushes to any branch trigger a nightly build. The version name will be formatted as `branch-nightly` (e.g., `dev-nightly`).
+*   **Build Number:** The `versionCode` is automatically incremented based on the GitHub Actions run number.
 
 ## License
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -50,12 +50,13 @@
 2.  **開啟專案:** 使用 Android Studio (建議 Ladybug | 2024.2.1 或更新版本) 開啟。
 3.  **編譯執行:** 連接 Android 手機 (Android 10+) 或使用模擬器執行。
 
-## CI/CD
+## CI/CD 與版本自動化
 
-本專案使用 GitHub Actions 進行持續整合與部署。
+本專案使用 GitHub Actions 進行持續整合與版本自動管理。
 
-*   **正式發布:** 推送至 `main` 分支會觸發正式版建置，並產生帶有版本號 (如 `v1.1.8.x`) 的 Release。
-*   **Nightly 建置:** 推送至 `dev` 分支會觸發預覽版建置，並更新 `nightly` tag。
+*   **正式發布 (Tag):** 推送標籤 (例如 `1.1.9`) 會觸發正式版建置，APK 版本將與標籤名稱一致。
+*   **Nightly 建置:** 推送至任何分支皆會觸發 Nightly Build，版本號格式為 `分支名-nightly`。
+*   **版本號碼 (VersionCode):** 自動使用 GitHub Actions 的執行次數 (`run_number`) 作為唯一遞增的版本代碼。
 
 ## 授權
 

--- a/log.md
+++ b/log.md
@@ -1,5 +1,14 @@
 # 更新日誌
 
+## DevOps
+*   **0119:** **實作三軌發布策略 (Official/Dev/Nightly)。**
+    *   **發布策略:**
+        *   **Official (v*):** 當 Tag 為 `v` 開頭時觸發，建立永久 Release，供一般使用者自動更新。
+        *   **Dev (dev branch):** 當推送到 `dev` 分支時觸發，更新 `latest-dev` 標籤，供 QA/測試人員使用。
+        *   **Nightly (others):** 當推送到其他分支 (如 `fix-xxx`) 時觸發，更新 `nightly` 標籤，供開發者實驗。
+    *   **CI/CD 更新:** 修改 `.github/workflows/android-cicd.yml`，實作上述三種觸發條件與發布邏輯。
+    *   **版本控制:** App 的 `versionCode` 與 `versionName` 已與 GitHub Actions 深度整合，自動對應 Build Number 與 Git 資訊。
+
 ## UI/UX 調整
 *   **0118:** **修復歷史記錄頁面月份標題顯示並完善英文翻譯。**
     *   **歷史記錄:**

--- a/todo.md
+++ b/todo.md
@@ -1,5 +1,24 @@
 # To-Do List
 
+- [x] **Implement Triple-Track Release Strategy**:
+    - [x] **Modify `.github/workflows/android-cicd.yml`**:
+        - [x] **Official Release**: Trigger on `v*` tags. Permanent release.
+        - [x] **Dev Release**: Trigger on `dev` branch push. Rolling tag `latest-dev`.
+        - [x] **Nightly Release**: Trigger on other branches push. Rolling tag `nightly`.
+- [x] **Implement Dual-Track Release Strategy**:
+    - [x] **Modify `.github/workflows/android-cicd.yml`**:
+        - [x] Update `VERSION_NAME` env injection to support nightly suffix logic.
+        - [x] Replace Release steps with "Official Release" (Tags) and "Nightly Release" (Push) dual tracks.
+        - [x] Use `marvinpinto/action-automatic-releases@latest` for Nightly builds (rolling tag).
+        - [x] Use `softprops/action-gh-release@v1` for Official releases (permanent tags).
+- [x] **CI/CD Versioning Automation**:
+    - [x] **Modify `app/build.gradle.kts`**:
+        - [x] Update `versionCode` to use `BUILD_NUMBER` env var (fallback to git commit count).
+        - [x] Update `versionName` to use `VERSION_NAME` env var (fallback to git/config based name).
+    - [x] **Modify `.github/workflows/android-cicd.yml`**:
+        - [x] Add `tags` trigger to `on: push`.
+        - [x] Inject `BUILD_NUMBER` (run_number) and `VERSION_NAME` (ref_name logic) into `Build with Gradle` step.
+        - [x] Ensure APK renaming logic handles the new version name correctly.
 - [x] **CI/CD Fixes**:
     - [x] 修復 GitHub Actions 中 `r0adkll/sign-android-release` 發生錯誤的問題 (`buildTools` 參數無效及找不到 build tools)。改用手動 `apksigner` 指令簽署。
     - [x] **優化簽名流程**:


### PR DESCRIPTION
This commit overhauls the CI/CD pipeline to support a tiered release system (Official, Dev, Nightly) and integrates dynamic versioning injection directly from GitHub Actions into the Gradle build process.

### Key Changes:

-   **GitHub Actions (`android-cicd.yml`):**
    -   **Triple-Track Strategy:**
        -   **Official Release:** Triggered by `v*` tags. Creates a permanent release using `softprops/action-gh-release`.
        -   **Dev Release:** Triggered by pushes to the `dev` branch. Updates a rolling `latest-dev` tag using `marvinpinto/action-automatic-releases`.
        -   **Nightly Release:** Triggered by pushes to feature branches (excluding main/master). Updates a rolling `nightly` tag.
    -   **Versioning Injection:** Added `BUILD_NUMBER` and `VERSION_NAME` environment variables to the Gradle build step to sync APK metadata with the CI run.

-   **Gradle Configuration (`build.gradle.kts`):**
    -   Updated `versionCode` and `versionName` logic to prioritize environment variables (CI context) over local Git calculation, ensuring consistent versioning between CI builds and artifacts.

-   **Documentation:**
    -   **`README.md` / `README_cn.md`:** Updated CI/CD sections to explain the new tag-based release triggers and automated version numbering.
    -   **`log.md`:** Added entry `0119` detailing the DevOps updates.
    -   **`todo.md`:** Marked CI/CD strategy and versioning tasks as complete.