### PR TITLE
fix: Prevent recursive opening of Settings screen

### DIFF
--- a/app/src/main/java/com/example/medicationreminderapp/MainActivity.kt
+++ b/app/src/main/java/com/example/medicationreminderapp/MainActivity.kt
@@ -137,6 +137,7 @@ class MainActivity : AppCompatActivity(), BluetoothLeManager.BleListener {
         supportActionBar?.setDisplayHomeAsUpEnabled(isFragmentOnBackStack)
         binding.tabLayout.visibility = if (isFragmentOnBackStack) View.GONE else View.VISIBLE
         binding.viewPager.visibility = if (isFragmentOnBackStack) View.GONE else View.VISIBLE
+        invalidateOptionsMenu()
     }
 
     private fun applyCharacterTheme() {
@@ -175,6 +176,11 @@ class MainActivity : AppCompatActivity(), BluetoothLeManager.BleListener {
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         menuInflater.inflate(R.menu.main_menu, menu)
         return true
+    }
+
+    override fun onPrepareOptionsMenu(menu: Menu): Boolean {
+        menu.findItem(R.id.action_settings)?.isVisible = supportFragmentManager.backStackEntryCount == 0
+        return super.onPrepareOptionsMenu(menu)
     }
 
     private fun setupViewPagerAndTabs() {

--- a/log.md
+++ b/log.md
@@ -1,5 +1,10 @@
 # 更新日誌
 
+## UI/UX 調整
+*   **0127:** **修復設定頁面重複開啟問題。**
+    *   **選單控制:** 在 `MainActivity.kt` 中實作了 `onPrepareOptionsMenu`，根據 Fragment BackStack 的狀態動態顯示或隱藏設定按鈕 (`action_settings`)。
+    *   **邏輯:** 當使用者進入設定頁面 (BackStack Count > 0) 時，隱藏 Toolbar 上的設定圖示，防止使用者重複點擊堆疊多個設定頁面；回到主頁面時則重新顯示。
+
 ## Bug Fixes
 *   **0127:** **修復設定頁面「關於」區塊無英文翻譯問題。**
     *   **國際化 (i18n):** 將 `preferences.xml` 中硬編碼的中文標題 ("關於", "作者", "版本") 提取至 `strings.xml` 資源檔 (`about_category`, `about_author`, `about_version`)。


### PR DESCRIPTION
This commit resolves a UI/UX issue where the settings menu item remained active while viewing the settings screen, allowing users to stack multiple instances. It dynamically controls the visibility of the settings action button based on the navigation state.

### Key Changes:

-   **`MainActivity.kt`:**
    -   **Dynamic Menu Visibility:** Implemented `onPrepareOptionsMenu` to hide the `action_settings` item when a fragment is on the back stack (i.e., when `backStackEntryCount > 0`).
    -   **Menu Invalidation:** Added `invalidateOptionsMenu()` to `updateUiForFragment` to ensure the menu state refreshes immediately upon entering or exiting sub-fragments.

-   **`log.md`:**
    -   **Changelog:** Documented the fix for the repeated settings page opening issue under "UI/UX Adjustments".