### PR TITLE
feat: Implement user-selectable update channels and refactor version …

### DIFF
--- a/app/src/main/java/com/example/medicationreminderapp/ReminderSettingsFragment.kt
+++ b/app/src/main/java/com/example/medicationreminderapp/ReminderSettingsFragment.kt
@@ -71,12 +71,16 @@ class ReminderSettingsFragment : Fragment() {
         setupListeners()
     }
 
-    private fun updateCharacterImage() {
+    private fun getCharacterImageRes(): Int {
         val character = sharedPreferences.getString("character", "kuromi")
-        val imageRes = when (character) {
+        return when (character) {
             "chibi_maruko_chan" -> R.drawable.chibi_maruko_chan
             else -> R.drawable.kuromi
         }
+    }
+
+    private fun updateCharacterImage() {
+        val imageRes = getCharacterImageRes()
         
         // Hide image if medication cards are being displayed (i.e., user is adding/editing)
         // Check if medication cards are visible/present
@@ -86,6 +90,11 @@ class ReminderSettingsFragment : Fragment() {
              binding.kuromiImage.visibility = View.VISIBLE
         }
         binding.kuromiImage.setImageResource(imageRes)
+
+        // Update images in dynamic forms
+        medicationCards.forEach { (cardBinding, _) ->
+             cardBinding.kuromiImageView.setImageResource(imageRes)
+        }
     }
 
     private fun setupObservers() {
@@ -287,6 +296,9 @@ class ReminderSettingsFragment : Fragment() {
         cardBinding.dosageSlider.addOnChangeListener { _, value, _ ->
             cardBinding.dosageLabelTextView.text = getString(R.string.dosage_pills, value.toInt())
         }
+
+        // Initialize character image for the new card
+        cardBinding.kuromiImageView.setImageResource(getCharacterImageRes())
     }
 
     private fun updateAllSlotSpinners() {

--- a/log.md
+++ b/log.md
@@ -1,6 +1,12 @@
 # 更新日誌
 
 ## 2025-01-27
+### UI/UX
+*   **動態表單角色圖示修復:**
+    *   修復在 `ReminderSettingsFragment` 中，動態生成的藥物輸入表單 (`medication_input_item.xml`) 內的圖片固定顯示為酷洛米的問題。
+    *   現在新增或編輯藥物時，表單內的圖片會正確跟隨設定頁面的角色選擇 (酷洛米/櫻桃小丸子) 進行切換。
+    *   實作 `updateCharacterImage()` 同步更新所有已存在的動態卡片圖片。
+
 ### DevOps
 *   **多頻道 (Multi-Channel) CI/CD 架構:**
     *   **動態頻道:** 支援基於 Git 分支名稱的動態更新頻道 (例如 `dev`, `feat-new-ui`, `fix-login-bug`)。每個分支現在都擁有獨立的 `update_<branch>.json` 更新設定檔與 Nightly Release。
@@ -12,7 +18,7 @@
     *   **Integer Overflow 修復:** 將 `.github/workflows/android-cicd.yml` 中的時間戳格式從 `yyyyMMddHH` 修改為 `yyMMddHH` (8位數)，防止 Version Code 溢出。
     *   **版本倒退修復:** 引入 `VERSION_CODE_OVERRIDE` 環境變數 (時間戳)，確保無論分支如何切換，新建置的版本號始終大於舊版本，解決 Commit Count 變少導致無法更新的問題。
 
-### UI/UX
+### UI/UX (Previous)
 *   **設定頁面「關於」區塊:**
     *   在 `SettingsFragment` 中實作了「關於」區塊的連結跳轉。
     *   點擊「作者」、「專案」、「版本」可分別開啟 GitHub Profile, Repo 與 Releases 頁面。
@@ -24,11 +30,7 @@
 *   **國際化 (i18n):** 修復設定頁面「關於」區塊無英文翻譯問題 (`values-en/strings.xml`)。
 *   **BuildConfig 類型錯誤:** 修正 `build.gradle.kts` 中 `UPDATE_CHANNEL` 的定義，確保生成的 Java/Kotlin 代碼類型正確 (`String`)。
 *   **UpdateManager 清理:** 移除重複變數宣告與無效的空值檢查。
-
-### Code Quality
-*   **SettingsFragment 優化:**
-    *   修復未使用導入與代碼警告 (使用 KTX `toUri()`)。
-    *   修正 `ListPreference` 動態新增頻道的邏輯錯誤 (型別不匹配)。
+*   **SettingsFragment 優化:** 修復 `ListPreference` 動態新增頻道的邏輯錯誤。
 
 ## 2025-01-26
 ### Bug Fixes


### PR DESCRIPTION
…logic

This commit introduces a user-facing option to switch between update channels (Stable, Dev, Nightly) directly in the app settings, decoupling the update source from the build branch. It also refines the version naming convention for nightly builds to improve readability while maintaining a monotonic version code for updates.

### Key Changes:

-   **Settings & UI (`SettingsFragment.kt`, `preferences.xml`):**
    -   **Selectable Channels:** Converted the "Update Channel" preference from read-only to a `ListPreference`, allowing users to choose `main`, `dev`, or `nightly`.
    -   **Dynamic Entries:** Implemented logic to dynamically inject the current build branch into the selection list if it is a non-standard channel (e.g., a feature branch), preventing users from being locked out of their origin channel.
    -   **Resources:** Updated `strings.xml` (en/cn) with channel arrays and labels.

-   **Update Logic (`UpdateManager.kt`):**
    -   **Preference-Based Check:** Refactored `checkForUpdates` to prioritize the user's selected channel from `SharedPreferences` over `BuildConfig.UPDATE_CHANNEL`.
    -   **Enhanced Comparison:** Added a fallback mechanism to compare versions based on "Commit Count" extracted from the version string, ensuring accurate update detection for nightly builds where semantic versioning might be ambiguous.

-   **Build Configuration (`build.gradle.kts`):**
    -   **Readable Version Names:** Modified the version naming logic for non-production builds. `versionName` now uses the Git commit count (e.g., `nightly 161`) for readability, while `versionCode` remains timestamp-based to ensure proper upgrade paths.

-   **Documentation:**
    -   **README:** Updated English and Chinese documentation to explain the new "Selectable Channels" feature.
    -   **`log.md`:** Recorded the implementation of multi-channel switching and version display fixes.