### PR TITLE
fix: Correct branch normalization in CI cleanup job

### DIFF
--- a/.github/workflows/android-cicd.yml
+++ b/.github/workflows/android-cicd.yml
@@ -212,11 +212,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG_NAME="nightly-${{ env.CHANNEL_NAME }}"
-          echo "Attempting to delete Release and Tag: $TAG_NAME"
-          # Use GitHub CLI to delete release (which can also cleanup tag)
-          # || true prevents the workflow from failing if the release doesn't exist
-          gh release delete "$TAG_NAME" --cleanup-tag --yes || echo "Release $TAG_NAME not found or already deleted. Skipping."
+          # 1. 取得分支名稱
+          RAW_BRANCH="${{ github.event.ref }}"
+          
+          # 2. 將 '-' 與 '/' 替換為 '_' (匹配 Build 邏輯)
+          NORMALIZED_BRANCH=$(echo "$RAW_BRANCH" | sed 's/[\/\-]/\_/g')
+          
+          # 3. 組合正確的 Tag 名稱
+          TAG_NAME="nightly-${NORMALIZED_BRANCH}"
+          
+          echo "正在刪除: $TAG_NAME"
+          
+          # 4. 執行刪除
+          gh release delete "$TAG_NAME" --cleanup-tag --yes || true
           
       - name: Checkout gh-pages
         uses: actions/checkout@v4

--- a/log.md
+++ b/log.md
@@ -3,6 +3,9 @@
 ## 2025-01-27
 ### DevOps
 *   **CI/CD 修復:**
+    *   **Cleanup Job 邏輯修正:** 修正了 `android-cicd.yml` 中 `cleanup` job 的分支名稱處理邏輯。
+        *   **問題:** 刪除分支時，GitHub Actions 的 `delete` 事件直接使用原始分支名稱 (例如 `fix-nightly-del-bench`)，但 Build 階段產生的 Tag 已將 `-` 替換為 `_` (例如 `nightly-fix_nightly_del_bench`)，導致 Cleanup Job 找不到對應的 Release/Tag 進行刪除。
+        *   **解決:** 在 `cleanup` job 中加入了與 Build 階段一致的 `sed` 替換邏輯 (`s/[\/\-]/\_/g`)，確保產生的 `TAG_NAME` 正確匹配已存在的 Nightly Release。
     *   **Schema Validation 修正:** 修正了 `android-cicd.yml` 中 `on.delete` 觸發器的語法錯誤。原寫法導致 Schema validation 警告 "Validates to more than one variant" (空物件 `{}` 在 YAML 中有時會被誤判)。現改為使用明確的空物件語法 `delete: {}`，或完全依賴預設行為，最終確認寫法正確無誤。
     *   **Cleanup Job 優化:**
         *   棄用 `dev-drprasad/delete-tag-and-release` action，改用 GitHub CLI (`gh release delete`) 原生指令。


### PR DESCRIPTION
This commit fixes a logic error in the CI/CD cleanup workflow where nightly releases were not being deleted upon branch deletion. It aligns the branch name normalization logic in the cleanup job with the build job to ensure tag matching.

### Key Changes:

-   **CI/CD Workflow (`android-cicd.yml`):**
    -   **Branch Normalization:** Implemented `sed` logic to replace hyphens (`-`) and slashes (`/`) with underscores (`_`) in the branch name (`github.event.ref`).
    -   **Tag Consistency:** Updated the `TAG_NAME` generation to use the normalized branch name, ensuring it matches the naming convention used during the build process (e.g., matching `nightly-fix_nightly_del_bench` instead of `nightly-fix-nightly-del-bench`).

-   **Documentation:**
    -   **`log.md`:** Updated the changelog to document the fix regarding the mismatch between raw branch names and normalized release tags in the cleanup job.