### PR TITLE
fix: Refine CI/CD cleanup logic and normalize branch names

### DIFF
--- a/.github/workflows/android-cicd.yml
+++ b/.github/workflows/android-cicd.yml
@@ -200,23 +200,29 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Extract Branch Name and Channel
-        id: branch_info
-        run: |
-          RAW_BRANCH=${{ github.event.ref }}
-          SAFE_NAME=$(echo "$RAW_BRANCH" | sed 's/[\/\-]/\_/g')
-          echo "CHANNEL_NAME=$SAFE_NAME" >> $GITHUB_ENV
-          echo "Branch Deleted: $RAW_BRANCH (Channel: $SAFE_NAME)"
-
       - name: Delete Channel Release and Tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DELETED_BRANCH: ${{ github.event.ref }}
         run: |
-          TAG_NAME="nightly-${{ env.CHANNEL_NAME }}"
+          echo "Deleted Branch: $DELETED_BRANCH"
+          
+          # 1. 將 '-' 與 '/' 替換為 '_' (匹配 Build 邏輯)
+          # 使用 tr 替代 sed 避免轉義問題
+          NORMALIZED_BRANCH=$(echo "$DELETED_BRANCH" | tr '/-' '__')
+          
+          # 3. 組合正確的 Tag 名稱
+          TAG_NAME="nightly-${NORMALIZED_BRANCH}"
+          
+          echo "Target Tag: $TAG_NAME"
+          
+          # 4. Debug: List current releases
+          echo "Listing current releases..."
+          gh release list --limit 5 || true
+
           echo "Attempting to delete Release and Tag: $TAG_NAME"
           
-          # Use GitHub CLI to delete release (which can also cleanup tag)
-          # || echo ... prevents the workflow from failing if the release doesn't exist
+          # 5. 執行刪除
           gh release delete "$TAG_NAME" --cleanup-tag --yes || echo "Release $TAG_NAME not found or already deleted. Skipping."
           
       - name: Checkout gh-pages
@@ -225,8 +231,13 @@ jobs:
           ref: gh-pages
           
       - name: Remove Channel JSON
+        env:
+          DELETED_BRANCH: ${{ github.event.ref }}
         run: |
-          JSON_FILE="update_${{ env.CHANNEL_NAME }}.json"
+          NORMALIZED_BRANCH=$(echo "$DELETED_BRANCH" | tr '/-' '__')
+          CHANNEL_NAME=$NORMALIZED_BRANCH
+          
+          JSON_FILE="update_${CHANNEL_NAME}.json"
           if [ -f "$JSON_FILE" ]; then
             echo "Removing $JSON_FILE..."
             git config --global user.name 'github-actions[bot]'

--- a/todo.md
+++ b/todo.md
@@ -1,6 +1,6 @@
 # 待辦事項 (To-Do List)
 
-- [ ] DevOps: 確認並優化 `android-cicd.yml` 的 Cleanup 邏輯
-    - [ ] 移除 `cleanup` job 中重複的 `Extract Branch Name` 步驟，將邏輯統一整合至刪除步驟中，避免變數傳遞問題。
-    - [ ] 確保 `sed` 語法與 Build job 完全一致。
-    - [ ] **重要提醒:** 必須告知使用者 Cleanup Workflow 需合併至 Main 分支才生效。
+- [ ] DevOps: 修復 `android-cicd.yml` Cleanup Job
+    - [ ] 將 `github.event.ref` 放入環境變數 `DELETED_BRANCH`，避免直接在 script 中注入導致的潛在問題。
+    - [ ] 改用 `tr '/-' '__'` 替換 `sed`，避免正則表達式在 YAML 中的轉義問題。
+    - [ ] 增加 `gh release list` 除錯訊息，以便在失敗時確認當前 Release 列表。


### PR DESCRIPTION
This commit addresses issues in the Android CI/CD cleanup workflow where branch names were not correctly resolved across steps. It unifies the branch normalization logic, replaces `sed` with `tr` for reliability, and ensures proper environment variable injection.

### Key Changes:

-   **CI/CD Workflow (`android-cicd.yml`):**
    -   **Logic Consolidation:** Removed the separate "Extract Branch Name" step. Branch normalization logic is now contained directly within the "Delete Channel Release" and "Remove Channel JSON" steps to prevent variable scoping issues.
    -   **Normalization Tooling:** Switched from `sed` to `tr '/-' '__'` to safely replace characters in branch names without potential regex escaping conflicts.
    -   **Environment Injection:** Explicitly mapped `${{ github.event.ref }}` to the `DELETED_BRANCH` environment variable to ensure the script context receives the correct git reference.
    -   **Debugging:** Added `gh release list` to the workflow output to assist in troubleshooting if release deletion fails.

-   **Documentation:**
    -   **`log.md`:** Updated the changelog with details regarding the "Third Attempt" at fixing the cleanup job, noting the switch to `tr` and environment variable improvements.
    -   **`todo.md`:** Updated the DevOps task list to reflect the specific fixes applied (using `tr` and adding debug info).